### PR TITLE
feat(prod): have a prod event successfully building and emitting data

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -1,8 +1,7 @@
 const { WLS } = require("./events");
-
+const { rehydrateFs } = require("./fsUtils");
 const vscode = require("vscode");
 const LanguageClientDispatcher = require("./languageClientDispatcher");
-const fs = require("./fs.js");
 
 /** @typedef {import('webpack/lib/Compiler.js')} Compiler */
 /** @typedef {import('webpack/lib/Stats.js')} Stats */
@@ -51,7 +50,8 @@ const activate = context => {
   dispatcher.onNotification(WLS.WEBPACK_CONFIG_PROD_BUILD_SUCCESS, (params, issuer) => {
     dispatcher.dispatch(WLS.WEBPACK_CONFIG_PROD_BUILD_SUCCESS, params);
 
-    console.log(params, fs);
+    const fs = rehydrateFs(params.fs);
+    console.log(fs.readdirSync(params.stats.outputPath));
   });
 
   dispatcher.startAll();

--- a/src/fs.js
+++ b/src/fs.js
@@ -1,4 +1,0 @@
-const MemoryFileSystem = require("memory-fs");
-const fs = new MemoryFileSystem();
-
-module.exports = fs;

--- a/src/fsUtils.js
+++ b/src/fsUtils.js
@@ -1,0 +1,24 @@
+/** @typedef {import("memory-fs")} MemoryFileSystem */
+
+const MemoryFileSystem = require("memory-fs");
+
+/**
+ * This fn allows you to take a serialized fs instance sent between Language Service Notifications,
+ * and rehydrate it as if it was a shared MemoryFileSystem instance
+ * 
+ * ```js
+dispatcher.onNotification(WLS.WEBPACK_CONFIG_PROD_BUILD_SUCCESS, (params, issuer) => {
+  dispatcher.dispatch(WLS.WEBPACK_CONFIG_PROD_BUILD_SUCCESS, params);
+
+  const fs = rehydrateFs(params.fs);
+  console.log(fs.readdirSync(params.stats.outputPath));
+});
+```
+ * 
+ * @param {MemoryFileSystem|{data: Object}} memFsInstance
+ */
+const rehydrateFs = memFsInstance => {
+  return new MemoryFileSystem(memFsInstance.data);
+};
+
+exports.rehydrateFs = rehydrateFs;

--- a/src/servers/webpackProductionServer.js
+++ b/src/servers/webpackProductionServer.js
@@ -1,6 +1,6 @@
 const webpack = require("webpack");
 const webpackMerge = require("webpack-merge");
-const fs = require("../fs.js");
+const MemoryFileSystem = require("memory-fs");
 
 const makeWebpackCompiler = require("../build/makeWebpackCompiler");
 const { WLS } = require("../events");
@@ -14,6 +14,7 @@ let documents = new TextDocuments();
 let hasConfigurationCapability = false;
 let hasWorkspaceFolderCapability = false;
 let hasDiagnosticRelatedInformationCapability = false;
+let fs;
 
 /** @type {string=} */
 let workspacePath;
@@ -56,7 +57,7 @@ connection.onInitialized(async params => {
 
   /** @type {Compiler} */
   webpackCompilerInstance = compiler;
-  webpackCompilerInstance.outputFileSystem = fs;
+  fs = webpackCompilerInstance.outputFileSystem = new MemoryFileSystem();
 });
 
 connection.onNotification(WLS.WEBPACK_SERVE_BUILD_SUCCESS, params => {
@@ -64,7 +65,7 @@ connection.onNotification(WLS.WEBPACK_SERVE_BUILD_SUCCESS, params => {
     if (err !== null) {
       connection.sendNotification(WLS.WEBPACK_CONFIG_PROD_BUILD_ERROR, { stats: stats.toJson() });
     } else {
-      connection.sendNotification(WLS.WEBPACK_CONFIG_PROD_BUILD_SUCCESS, { stats: stats.toJson() });
+      connection.sendNotification(WLS.WEBPACK_CONFIG_PROD_BUILD_SUCCESS, { stats: stats.toJson(), fs });
     }
   });
 });


### PR DESCRIPTION
* Prod Build Event
* Now there is a rehydrateFs() fn which will take a memoryfilesystem instance (or 	`{data: Object}` and rehydrate it to call fns like `readdirSync()` etc.
*