### PR TITLE
feat(builtModules): Create working built modules tree view. Displays …

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,15 @@
         "command": "extension.webpackServe",
         "title": "Webpack Serve"
       }
-    ]
+    ],
+    "views": {
+      "built-modules": [
+        {
+          "id": "builtModules",
+          "name": "Built Modules Explorer"
+        }
+      ]
+    }
   },
   "scripts": {
     "postinstall": "node ./node_modules/vscode/bin/install"

--- a/src/extension.js
+++ b/src/extension.js
@@ -2,6 +2,7 @@ const { BCS, WLS } = require("./events");
 const { rehydrateFs } = require("./fsUtils");
 const vscode = require("vscode");
 const LanguageClientDispatcher = require("./languageClientDispatcher");
+const ModulesProvider = require("./treeviews/modulesProvider");
 
 /** @typedef {import('webpack/lib/Compiler.js')} Compiler */
 /** @typedef {import('webpack/lib/Stats.js')} Stats */
@@ -59,6 +60,11 @@ const activate = context => {
 
     console.log(params.coverage);
   });
+
+  // @ts-ignore
+  const modulesProvider = new ModulesProvider(workspace, context, dispatcher);
+  vscode.window.registerTreeDataProvider("builtModules", modulesProvider);
+  vscode.window.createTreeView("builtModulesView", { treeDataProvider: modulesProvider });
 
   dispatcher.startAll();
 };

--- a/src/treeviews/modulesProvider.js
+++ b/src/treeviews/modulesProvider.js
@@ -1,0 +1,81 @@
+const { TreeItem, TreeItemCollapsibleState, EventEmitter } = require("vscode");
+const LanguageClientDispatcher = require("../languageClientDispatcher");
+const path = require("path");
+const { WLS } = require("../events");
+
+/** @typedef {import("vscode").ExtensionContext} ExtensionContext */
+
+module.exports = class ModulesProvider {
+  /**
+   * @param {ExtensionContext} context
+   * @param {LanguageClientDispatcher} dispatcher
+   */
+  constructor(workspace, context, dispatcher) {
+    this._modules = [];
+    this._workspace = workspace;
+    this._context = context;
+    this._onDidChangeTreeData = new EventEmitter();
+    this.rootPath = this._workspace.rootPath;
+    this.onDidChangeTreeData = this._onDidChangeTreeData.event;
+    this.outputPath = "";
+
+    dispatcher.onNotification(WLS.WEBPACK_SERVE_BUILD_SUCCESS, params => {
+      const { stats } = params;
+
+      this._modules = stats.modules;
+      this.refresh();
+    });
+  }
+
+  refresh(newModules) {
+    this._onDidChangeTreeData.fire();
+  }
+
+  /**
+   *
+   * @param {BuiltModule} element
+   * @returns {TreeItem}
+   */
+  getTreeItem(element) {
+    return element;
+  }
+
+  /**
+   * @param {any} rawModule
+   * @returns {BuiltModule}
+   */
+  createModuleFromStatsRecord(rawModule) {
+    if (rawModule.issuerPath) {
+      return new BuiltModule(rawModule.name, TreeItemCollapsibleState.Collapsed, rawModule);
+    } else {
+      return new BuiltModule(rawModule.name, TreeItemCollapsibleState.None);
+    }
+  }
+
+  getChildren(element) {
+    const modules = this._modules.filter(path => path.identifier.startsWith(this.rootPath));
+    let itemSelected;
+
+    if (element) {
+      itemSelected = true;
+    }
+
+    return new Promise(resolve => {
+      if (itemSelected) {
+        resolve(element.rawModuleData.issuerPath.map(this.createModuleFromStatsRecord, this));
+      }
+      resolve(modules.map(this.createModuleFromStatsRecord, this));
+    });
+  }
+};
+
+class BuiltModule extends TreeItem {
+  /**
+   * @param {string} label
+   * @param {any} collapsibleState
+   */
+  constructor(label, collapsibleState, rawModuleData = {}) {
+    super(label, collapsibleState);
+    this.rawModuleData = rawModuleData;
+  }
+}


### PR DESCRIPTION
This is an implementation of a TreeViewProvider and TreeView which is created to display all of the _users_ modules in a built bundle. (Currently filtering out webpack-dev-server modules). 

This shows the modules at top level and then the `module.issuerPath` which is an array of issuers from those.