### PR TITLE
Enable modules provider

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -69,9 +69,9 @@ const activate = context => {
 
   dispatcher.startAll();
   // @ts-ignore
-  // const modulesProvider = new ModulesProvider(workspace, context, dispatcher);
-  // vscode.window.registerTreeDataProvider("builtModulesView", modulesProvider);
-  // vscode.window.createTreeView("builtModulesView", { treeDataProvider: modulesProvider });
+  const modulesProvider = new ModulesProvider(workspace, context, dispatcher);
+  vscode.window.registerTreeDataProvider("builtModulesView", modulesProvider);
+  vscode.window.createTreeView("builtModulesView", { treeDataProvider: modulesProvider });
 };
 
 /**

--- a/src/treeviews/modulesProvider.js
+++ b/src/treeviews/modulesProvider.js
@@ -20,6 +20,7 @@ module.exports = class ModulesProvider {
     this.outputPath = "";
 
     dispatcher.onNotification(WLS.WEBPACK_SERVE_BUILD_SUCCESS, params => {
+      dispatcher.dispatch(WLS.WEBPACK_SERVE_BUILD_SUCCESS, params);
       const { stats } = params;
 
       this._modules = stats.modules;


### PR DESCRIPTION
Uncomment out the init code for modules provider.
Refire the WEBPACK_SERVE_BUILD_SUCCESS event in modules provider handler so other listeners can act on it (namely the webpackProductionServer)